### PR TITLE
Copying the requirements file before installing them.

### DIFF
--- a/beacons-observer/Dockerfile
+++ b/beacons-observer/Dockerfile
@@ -12,10 +12,10 @@ EXPOSE 5000
 
 ##### RUN IN PROD MODE (source code bundled into image) #######################
 
-# Install all dependencies
-RUN pip install -r requirements.txt
 # Copy the requirements to the container
 COPY src /app/src
+# Install all dependencies
+RUN pip install -r requirements.txt
 # Execute this command as default
 CMD ["python", "app.py"]
 


### PR DESCRIPTION
There was a bug in the Dockerfile: running in Prod Mode, it asked for the dependencies to be installed before copying the requirements file (lines 15 to 18 of ./beacons-observer-Dockerfile).
